### PR TITLE
Bump XZ version to 5.0.8 and change mirror

### DIFF
--- a/osx/setup-runtime
+++ b/osx/setup-runtime
@@ -189,7 +189,7 @@ GMP_DIR_VERSION=6.0.0
 LIBFFI_VERSION=3.2.1
 LIBYAML_VERSION=0.1.5
 SQLITE3_VERSION=3080702
-XZ_VERSION=5.0.7
+XZ_VERSION=5.0.8
 MYSQL_LIB_VERSION=6.1.5
 POSTGRESQL_VERSION=9.3.5
 export PATH="$RUNTIME_DIR/bin:$PATH"
@@ -435,7 +435,7 @@ if $SKIP_LIBLZMA; then
 	echo "Skipped."
 elif [[ ! -e "$RUNTIME_DIR/lib/liblzma.5.dylib" ]] || $FORCE_LIBLZMA; then
 	download_and_extract xz-$XZ_VERSION.tar.bz2 \
-		http://fossies.org/linux/misc/xz-$XZ_VERSION.tar.bz2
+		http://tukaani.org/xz/xz-$XZ_VERSION.tar.bz2
 	echo "Entering $RUNTIME_DIR/xz-$XZ_VERSION"
 	pushd xz-$XZ_VERSION >/dev/null
 


### PR DESCRIPTION
The official site of the project keeps copies of the older .tar.gz.

This commit closes #27