### PR TITLE
Fixed a crash when files were not there to delete

### DIFF
--- a/TUTORIAL-3.md
+++ b/TUTORIAL-3.md
@@ -51,8 +51,8 @@ Using the Rakefile from tutorial 2, create the gem bundle which is to be include
 Run these to remove any native extensions from that bundle:
 
     $ rm -rf packaging/vendor/ruby/*/extensions
-    $ find packaging/vendor/ruby/*/gems -name '*.so' | xargs rm
-    $ find packaging/vendor/ruby/*/gems -name '*.bundle' | xargs rm
+    $ find packaging/vendor/ruby/*/gems -name '*.so' | xargs rm -f
+    $ find packaging/vendor/ruby/*/gems -name '*.bundle' | xargs rm -f
 
 ## Dropping native extensions
 


### PR DESCRIPTION
The rake command was giving me errors on a fresh install of Tutorial 3. I added a check for xargs to not error out when the files were missing.

$ rake package

...
find packaging/vendor/ruby/*/gems -name '*.so' | xargs rm 
rm: missing operand
Try `rm --help' for more information.
rake aborted!
...

See also: https://github.com/phusion/traveling-ruby-native-extensions-demo/pull/1