### PR TITLE
update rakefile example to run without erroring

### DIFF
--- a/TUTORIAL-1.md
+++ b/TUTORIAL-1.md
@@ -155,7 +155,8 @@ Going through all of the above steps on every release is a hassle, so you should
 
 ```Ruby
 PACKAGE_NAME = "hello"
-VERSION = "1.0.0"
+PACKAGE_VERSION = "1.0.0"
+PACKAGE_MAIN = "hello.rb"
 TRAVELING_RUBY_VERSION = "20150210-2.1.5"
 
 desc "Package your app"
@@ -193,14 +194,15 @@ file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx.tar.gz" do
 end
 
 def create_package(target)
-  package_dir = "#{PACKAGE_NAME}-#{VERSION}-#{target}"
+  package_dir = "#{PACKAGE_NAME}-#{PACKAGE_VERSION}-#{target}"
   sh "rm -rf #{package_dir}"
   sh "mkdir -p #{package_dir}/lib/app"
-  sh "cp hello.rb #{package_dir}/lib/app/"
-  sh "mkdir #{package_dir}/lib/ruby"
+  sh "cp #{PACKAGE_MAIN} #{package_dir}/lib/app/"
+  sh "mkdir -p #{package_dir}/lib/ruby"
+  sh "mkdir -p packaging/"
   sh "tar -xzf packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-#{target}.tar.gz -C #{package_dir}/lib/ruby"
-  sh "cp packaging/wrapper.sh #{package_dir}/hello"
-  if !ENV['DIR_ONLY']
+  sh "cp packaging/wrapper.sh #{package_dir}/#{PACKAGE_NAME}"
+  if !ENV["DIR_ONLY"]
     sh "tar -czf #{package_dir}.tar.gz #{package_dir}"
     sh "rm -rf #{package_dir}"
   end

--- a/TUTORIAL-2.md
+++ b/TUTORIAL-2.md
@@ -172,7 +172,8 @@ We update the Rakefile so that all of the above steps are automated by running `
 require 'bundler/setup'
 
 PACKAGE_NAME = "hello"
-VERSION = "1.0.0"
+PACKAGE_VERSION = "1.0.0"
+PACKAGE_MAIN = "hello.rb"
 TRAVELING_RUBY_VERSION = "20150210-2.1.5"
 
 desc "Package your app"
@@ -225,19 +226,20 @@ file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx.tar.gz" do
 end
 
 def create_package(target)
-  package_dir = "#{PACKAGE_NAME}-#{VERSION}-#{target}"
+  package_dir = "#{PACKAGE_NAME}-#{PACKAGE_VERSION}-#{target}"
   sh "rm -rf #{package_dir}"
   sh "mkdir #{package_dir}"
   sh "mkdir -p #{package_dir}/lib/app"
-  sh "cp hello.rb #{package_dir}/lib/app/"
+  sh "cp #{PACKAGE_MAIN} #{package_dir}/lib/app/"
   sh "mkdir #{package_dir}/lib/ruby"
+  sh "mkdir -p packaging/"
   sh "tar -xzf packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-#{target}.tar.gz -C #{package_dir}/lib/ruby"
-  sh "cp packaging/wrapper.sh #{package_dir}/hello"
+  sh "cp packaging/wrapper.sh #{package_dir}/#{PACKAGE_NAME}"
   sh "cp -pR packaging/vendor #{package_dir}/lib/"
   sh "cp Gemfile Gemfile.lock #{package_dir}/lib/vendor/"
   sh "mkdir #{package_dir}/lib/vendor/.bundle"
   sh "cp packaging/bundler-config #{package_dir}/lib/vendor/.bundle/config"
-  if !ENV['DIR_ONLY']
+  if !ENV["DIR_ONLY"]
     sh "tar -czf #{package_dir}.tar.gz #{package_dir}"
     sh "rm -rf #{package_dir}"
   end

--- a/TUTORIAL-3.md
+++ b/TUTORIAL-3.md
@@ -128,7 +128,7 @@ hello world
 
 We update the Rakefile so that all of the above steps are automated by running `rake package`. The `package:bundle_install` task has been updated to remove any locally compiled native extensions. The various packaging tasks have been updated to extract platform-specific native extension binaries.
 
-```bash
+```ruby
 # For Bundler.with_clean_env
 require 'bundler/setup'
 

--- a/TUTORIAL-3.md
+++ b/TUTORIAL-3.md
@@ -14,33 +14,41 @@ Suppose that we want our hello world app from tutorial 2 to insert a row into an
 
 Traveling Ruby provides a specific version of the sqlite3 gem. See [the Traveling Ruby Amazon S3 bucket](http://traveling-ruby.s3-us-west-2.amazonaws.com/list.html). For version 20141215-2.1.5, version 1.3.9 is supplied. So we add the following to our Gemfile:
 
-    gem 'sqlite3', '1.3.9'
+```ruby
+gem 'sqlite3', '1.3.9'
+```
 
 Let's also modify hello.rb to do what we want:
 
-    #!/usr/bin/env ruby
-    require 'faker'
-    require 'sqlite3'
+```bash
+#!/usr/bin/env ruby
+require 'faker'
+require 'sqlite3'
 
-    db = SQLite3::Database.new("hello.sqlite3")
-    db.execute("create table if not exists foo (name varchar(255))")
-    db.execute("insert into foo values ('hello world')")
-    db.close
-    puts "Hello #{Faker::Name.name}, database file modified."
+db = SQLite3::Database.new("hello.sqlite3")
+db.execute("create table if not exists foo (name varchar(255))")
+db.execute("insert into foo values ('hello world')")
+db.close
+puts "Hello #{Faker::Name.name}, database file modified."
+```
 
 Then install your gem bundle:
 
-    $ bundle install
+```bash
+$ bundle install
+```
 
 Verify that the modified program works:
 
-    $ bundle exec ruby hello.rb
-    Hello Freida Walker, database file modified.
-    $ sqlite3 hello.sqlite3
-    sqlite> select * from foo;
-    name
-    -----------
-    hello world
+```bash
+$ bundle exec ruby hello.rb
+Hello Freida Walker, database file modified.
+$ sqlite3 hello.sqlite3
+sqlite> select * from foo;
+name
+-----------
+hello world
+```
 
 ## Preparing the gem bundle, without native extensions
 
@@ -48,20 +56,26 @@ Recall that the idea is that we create a package for every platform, and that we
 
 Using the Rakefile from tutorial 2, create the gem bundle which is to be included in packages:
 
-    $ rake package:bundle_install
+```bash
+$ rake package:bundle_install
+```
 
 Run these to remove any native extensions and compilation products from that bundle:
 
-    $ rm -rf packaging/vendor/ruby/*/extensions
-    $ find packaging/vendor/ruby/*/gems -name '*.so' | xargs rm -f
-    $ find packaging/vendor/ruby/*/gems -name '*.bundle' | xargs rm -f
-    $ find packaging/vendor/ruby/*/gems -name '*.o' | xargs rm -f
+```bash
+$ rm -rf packaging/vendor/ruby/*/extensions
+$ find packaging/vendor/ruby/*/gems -name '*.so' | xargs rm -f
+$ find packaging/vendor/ruby/*/gems -name '*.bundle' | xargs rm -f
+$ find packaging/vendor/ruby/*/gems -name '*.o' | xargs rm -f
+```
 
 ## Dropping native extensions
 
 Now you are ready to drop platform-specific native extensions inside the packages. First, create the package directories:
 
-    $ rake package DIR_ONLY=1
+```bash
+$ rake package DIR_ONLY=1
+```
 
 Next you must download the necessary native extensions, and extract them into `<PACKAGE DIR>/lib/vendor`. You can find native extensions at [the Traveling Ruby Amazon S3 bucket](http://traveling-ruby.s3-us-west-2.amazonaws.com/list.html). Suppose that you're using Traveling Ruby version 20141215-2.1.5, which supplies sqlite3 version 1.3.9. Download and extract the precompiled binaries as follows. Remember that we're using CloudFront domain "http://d6r77u77i8pq3.cloudfront.net" to speed up downloads.
 
@@ -87,141 +101,147 @@ Next you must download the necessary native extensions, and extract them into `<
 
 Package the directories and finalize the packages:
 
-    $ tar -czf hello-1.0.0-linux-x86.tar.gz hello-1.0.0-linux-x86
-    $ tar -czf hello-1.0.0-linux-x86_64.tar.gz hello-1.0.0-linux-x86_64
-    $ tar -czf hello-1.0.0-osx.tar.gz hello-1.0.0-osx
-    $ rm -rf hello-1.0.0-linux-x86
-    $ rm -rf hello-1.0.0-linux-x86_64
-    $ rm -rf hello-1.0.0-osx
+```bash
+$ tar -czf hello-1.0.0-linux-x86.tar.gz hello-1.0.0-linux-x86
+$ tar -czf hello-1.0.0-linux-x86_64.tar.gz hello-1.0.0-linux-x86_64
+$ tar -czf hello-1.0.0-osx.tar.gz hello-1.0.0-osx
+$ rm -rf hello-1.0.0-linux-x86
+$ rm -rf hello-1.0.0-linux-x86_64
+$ rm -rf hello-1.0.0-osx
+```
 
 Now you can test whether it works. Suppose that you're developing on OS X. Extract the OS X package and test it:
 
-    $ tar xzf hello-1.0.0-osx.tar.gz
-    $ cd hello-1.0.0-osx
-    $ ./hello
-    Database file modified. (in red)
-    $ sqlite3 hello.sqlite3
-    sqlite> select * from foo;
-    name
-    -----------
-    hello world
+```bash
+$ tar xzf hello-1.0.0-osx.tar.gz
+$ cd hello-1.0.0-osx
+$ ./hello
+Database file modified. (in red)
+$ sqlite3 hello.sqlite3
+sqlite> select * from foo;
+name
+-----------
+hello world
+```
 
 ## Automating the process using Rake
 
 We update the Rakefile so that all of the above steps are automated by running `rake package`. The `package:bundle_install` task has been updated to remove any locally compiled native extensions. The various packaging tasks have been updated to extract platform-specific native extension binaries.
 
-	# For Bundler.with_clean_env
-	require 'bundler/setup'
+```bash
+# For Bundler.with_clean_env
+require 'bundler/setup'
 
-	PACKAGE_NAME = "hello"
-	VERSION = "1.0.0"
-	TRAVELING_RUBY_VERSION = "20150210-2.1.5"
-	SQLITE3_VERSION = "1.3.9"  # Must match Gemfile
+PACKAGE_NAME = "hello"
+VERSION = "1.0.0"
+TRAVELING_RUBY_VERSION = "20150210-2.1.5"
+SQLITE3_VERSION = "1.3.9"  # Must match Gemfile
 
-	desc "Package your app"
-	task :package => ['package:linux:x86', 'package:linux:x86_64', 'package:osx']
+desc "Package your app"
+task :package => ['package:linux:x86', 'package:linux:x86_64', 'package:osx']
 
-	namespace :package do
-	  namespace :linux do
-	    desc "Package your app for Linux x86"
-	    task :x86 => [:bundle_install,
-	      "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86.tar.gz",
-	      "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86-sqlite3-#{SQLITE3_VERSION}.tar.gz"
-	    ] do
-	      create_package("linux-x86")
-	    end
+namespace :package do
+  namespace :linux do
+    desc "Package your app for Linux x86"
+    task :x86 => [:bundle_install,
+      "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86.tar.gz",
+      "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86-sqlite3-#{SQLITE3_VERSION}.tar.gz"
+    ] do
+      create_package("linux-x86")
+    end
 
-	    desc "Package your app for Linux x86_64"
-	    task :x86_64 => [:bundle_install,
-	      "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86_64.tar.gz",
-	      "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86_64-sqlite3-#{SQLITE3_VERSION}.tar.gz"
-	    ] do
-	      create_package("linux-x86_64")
-	    end
-	  end
+    desc "Package your app for Linux x86_64"
+    task :x86_64 => [:bundle_install,
+      "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86_64.tar.gz",
+      "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86_64-sqlite3-#{SQLITE3_VERSION}.tar.gz"
+    ] do
+      create_package("linux-x86_64")
+    end
+  end
 
-	  desc "Package your app for OS X"
-	  task :osx => [:bundle_install,
-	    "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx.tar.gz",
-	    "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx-sqlite3-#{SQLITE3_VERSION}.tar.gz"
-	  ] do
-	    create_package("osx")
-	  end
+  desc "Package your app for OS X"
+  task :osx => [:bundle_install,
+    "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx.tar.gz",
+    "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx-sqlite3-#{SQLITE3_VERSION}.tar.gz"
+  ] do
+    create_package("osx")
+  end
 
-	  desc "Install gems to local directory"
-	  task :bundle_install do
-	    if RUBY_VERSION !~ /^2\.1\./
-	      abort "You can only 'bundle install' using Ruby 2.1, because that's what Traveling Ruby uses."
-	    end
-	    sh "rm -rf packaging/tmp"
-	    sh "mkdir packaging/tmp"
-	    sh "cp Gemfile Gemfile.lock packaging/tmp/"
-	    Bundler.with_clean_env do
-	      sh "cd packaging/tmp && env BUNDLE_IGNORE_CONFIG=1 bundle install --path ../vendor --without development"
-	    end
-	    sh "rm -rf packaging/tmp"
-	    sh "rm -f packaging/vendor/*/*/cache/*"
-	    sh "rm -rf packaging/vendor/ruby/*/extensions"
-	    sh "find packaging/vendor/ruby/*/gems -name '*.so' | xargs rm -f"
-	    sh "find packaging/vendor/ruby/*/gems -name '*.bundle' | xargs rm -f"
-	    sh "find packaging/vendor/ruby/*/gems -name '*.o' | xargs rm -f"
-	  end
-	end
+  desc "Install gems to local directory"
+  task :bundle_install do
+    if RUBY_VERSION !~ /^2\.1\./
+      abort "You can only 'bundle install' using Ruby 2.1, because that's what Traveling Ruby uses."
+    end
+    sh "rm -rf packaging/tmp"
+    sh "mkdir packaging/tmp"
+    sh "cp Gemfile Gemfile.lock packaging/tmp/"
+    Bundler.with_clean_env do
+      sh "cd packaging/tmp && env BUNDLE_IGNORE_CONFIG=1 bundle install --path ../vendor --without development"
+    end
+    sh "rm -rf packaging/tmp"
+    sh "rm -f packaging/vendor/*/*/cache/*"
+    sh "rm -rf packaging/vendor/ruby/*/extensions"
+    sh "find packaging/vendor/ruby/*/gems -name '*.so' | xargs rm -f"
+    sh "find packaging/vendor/ruby/*/gems -name '*.bundle' | xargs rm -f"
+    sh "find packaging/vendor/ruby/*/gems -name '*.o' | xargs rm -f"
+  end
+end
 
-	file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86.tar.gz" do
-	  download_runtime("linux-x86")
-	end
+file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86.tar.gz" do
+  download_runtime("linux-x86")
+end
 
-	file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86_64.tar.gz" do
-	  download_runtime("linux-x86_64")
-	end
+file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86_64.tar.gz" do
+  download_runtime("linux-x86_64")
+end
 
-	file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx.tar.gz" do
-	  download_runtime("osx")
-	end
+file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx.tar.gz" do
+  download_runtime("osx")
+end
 
-	file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86-sqlite3-#{SQLITE3_VERSION}.tar.gz" do
-	  download_native_extension("linux-x86", "sqlite3-#{SQLITE3_VERSION}")
-	end
+file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86-sqlite3-#{SQLITE3_VERSION}.tar.gz" do
+  download_native_extension("linux-x86", "sqlite3-#{SQLITE3_VERSION}")
+end
 
-	file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86_64-sqlite3-#{SQLITE3_VERSION}.tar.gz" do
-	  download_native_extension("linux-x86_64", "sqlite3-#{SQLITE3_VERSION}")
-	end
+file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86_64-sqlite3-#{SQLITE3_VERSION}.tar.gz" do
+  download_native_extension("linux-x86_64", "sqlite3-#{SQLITE3_VERSION}")
+end
 
-	file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx-sqlite3-#{SQLITE3_VERSION}.tar.gz" do
-	  download_native_extension("osx", "sqlite3-#{SQLITE3_VERSION}")
-	end
+file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx-sqlite3-#{SQLITE3_VERSION}.tar.gz" do
+  download_native_extension("osx", "sqlite3-#{SQLITE3_VERSION}")
+end
 
-	def create_package(target)
-	  package_dir = "#{PACKAGE_NAME}-#{VERSION}-#{target}"
-	  sh "rm -rf #{package_dir}"
-	  sh "mkdir #{package_dir}"
-	  sh "mkdir -p #{package_dir}/lib/app"
-	  sh "cp hello.rb #{package_dir}/lib/app/"
-	  sh "mkdir #{package_dir}/lib/ruby"
-	  sh "tar -xzf packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-#{target}.tar.gz -C #{package_dir}/lib/ruby"
-	  sh "cp packaging/wrapper.sh #{package_dir}/hello"
-	  sh "cp -pR packaging/vendor #{package_dir}/lib/"
-	  sh "cp Gemfile Gemfile.lock #{package_dir}/lib/vendor/"
-	  sh "mkdir #{package_dir}/lib/vendor/.bundle"
-	  sh "cp packaging/bundler-config #{package_dir}/lib/vendor/.bundle/config"
-	  sh "tar -xzf packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-#{target}-sqlite3-#{SQLITE3_VERSION}.tar.gz " +
-	    "-C #{package_dir}/lib/vendor/ruby"
-	  if !ENV['DIR_ONLY']
-	    sh "tar -czf #{package_dir}.tar.gz #{package_dir}"
-	    sh "rm -rf #{package_dir}"
-	  end
-	end
+def create_package(target)
+  package_dir = "#{PACKAGE_NAME}-#{VERSION}-#{target}"
+  sh "rm -rf #{package_dir}"
+  sh "mkdir #{package_dir}"
+  sh "mkdir -p #{package_dir}/lib/app"
+  sh "cp hello.rb #{package_dir}/lib/app/"
+  sh "mkdir #{package_dir}/lib/ruby"
+  sh "tar -xzf packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-#{target}.tar.gz -C #{package_dir}/lib/ruby"
+  sh "cp packaging/wrapper.sh #{package_dir}/hello"
+  sh "cp -pR packaging/vendor #{package_dir}/lib/"
+  sh "cp Gemfile Gemfile.lock #{package_dir}/lib/vendor/"
+  sh "mkdir #{package_dir}/lib/vendor/.bundle"
+  sh "cp packaging/bundler-config #{package_dir}/lib/vendor/.bundle/config"
+  sh "tar -xzf packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-#{target}-sqlite3-#{SQLITE3_VERSION}.tar.gz " +
+    "-C #{package_dir}/lib/vendor/ruby"
+  if !ENV['DIR_ONLY']
+    sh "tar -czf #{package_dir}.tar.gz #{package_dir}"
+    sh "rm -rf #{package_dir}"
+  end
+end
 
-	def download_runtime(target)
-	  sh "cd packaging && curl -L -O --fail " +
-	    "http://d6r77u77i8pq3.cloudfront.net/releases/traveling-ruby-#{TRAVELING_RUBY_VERSION}-#{target}.tar.gz"
-	end
+def download_runtime(target)
+  sh "cd packaging && curl -L -O --fail " +
+    "http://d6r77u77i8pq3.cloudfront.net/releases/traveling-ruby-#{TRAVELING_RUBY_VERSION}-#{target}.tar.gz"
+end
 
-	def download_native_extension(target, gem_name_and_version)
-	  sh "curl -L --fail -o packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-#{target}-#{gem_name_and_version}.tar.gz " +
-	    "http://d6r77u77i8pq3.cloudfront.net/releases/traveling-ruby-gems-#{TRAVELING_RUBY_VERSION}-#{target}/#{gem_name_and_version}.tar.gz"
-	end
+def download_native_extension(target, gem_name_and_version)
+  sh "curl -L --fail -o packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-#{target}-#{gem_name_and_version}.tar.gz " +
+    "http://d6r77u77i8pq3.cloudfront.net/releases/traveling-ruby-gems-#{TRAVELING_RUBY_VERSION}-#{target}/#{gem_name_and_version}.tar.gz"
+end
+```
 
 ## Conclusion
 

--- a/TUTORIAL-3.md
+++ b/TUTORIAL-3.md
@@ -133,7 +133,8 @@ We update the Rakefile so that all of the above steps are automated by running `
 require 'bundler/setup'
 
 PACKAGE_NAME = "hello"
-VERSION = "1.0.0"
+PACKAGE_VERSION = "1.0.0"
+PACKAGE_MAIN = "hello.rb"
 TRAVELING_RUBY_VERSION = "20150210-2.1.5"
 SQLITE3_VERSION = "1.3.9"  # Must match Gemfile
 
@@ -212,21 +213,22 @@ file "packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx-sqlite3-#{SQLITE3_V
 end
 
 def create_package(target)
-  package_dir = "#{PACKAGE_NAME}-#{VERSION}-#{target}"
+  package_dir = "#{PACKAGE_NAME}-#{PACKAGE_VERSION}-#{target}"
   sh "rm -rf #{package_dir}"
   sh "mkdir #{package_dir}"
   sh "mkdir -p #{package_dir}/lib/app"
-  sh "cp hello.rb #{package_dir}/lib/app/"
+  sh "cp #{PACKAGE_MAIN} #{package_dir}/lib/app/"
   sh "mkdir #{package_dir}/lib/ruby"
+  sh "mkdir -p packaging/"
   sh "tar -xzf packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-#{target}.tar.gz -C #{package_dir}/lib/ruby"
-  sh "cp packaging/wrapper.sh #{package_dir}/hello"
+  sh "cp packaging/wrapper.sh #{package_dir}/#{PACKAGE_NAME}"
   sh "cp -pR packaging/vendor #{package_dir}/lib/"
   sh "cp Gemfile Gemfile.lock #{package_dir}/lib/vendor/"
   sh "mkdir #{package_dir}/lib/vendor/.bundle"
   sh "cp packaging/bundler-config #{package_dir}/lib/vendor/.bundle/config"
   sh "tar -xzf packaging/traveling-ruby-#{TRAVELING_RUBY_VERSION}-#{target}-sqlite3-#{SQLITE3_VERSION}.tar.gz " +
     "-C #{package_dir}/lib/vendor/ruby"
-  if !ENV['DIR_ONLY']
+  if !ENV["DIR_ONLY"]
     sh "tar -czf #{package_dir}.tar.gz #{package_dir}"
     sh "rm -rf #{package_dir}"
   end

--- a/TUTORIAL-4.md
+++ b/TUTORIAL-4.md
@@ -53,17 +53,17 @@ We must update the `create_package` method so that it generates the package slig
 def create_package(target, os_type = :unix)
 ```
 
-This method contains a line which copies `wrapper.sh`, but we'll want to copy `wrapper.bat` when creating Windows packages. 
+This method contains a line which copies `wrapper.sh`, but we'll want to copy `wrapper.bat` when creating Windows packages.
 
 ```Ruby
 # Look for:
-sh "cp packaging/wrapper.sh #{package_dir}/hello"
+sh "cp packaging/wrapper.sh #{package_dir}/#{PACKAGE_NAME}"
 
 # Replace it with:
 if os_type == :unix
-  sh "cp packaging/wrapper.sh #{package_dir}/hello"
+  sh "cp packaging/wrapper.sh #{package_dir}/#{PACKAGE_NAME}"
 else
-  sh "cp packaging/wrapper.bat #{package_dir}/hello.bat"
+  sh "cp packaging/wrapper.bat #{package_dir}/#{PACKAGE_NAME}.bat"
 end
 ```
 


### PR DESCRIPTION
This fixes an issue which would cause the Rake task to error out when running it with an app name other than `hello` and without first creating the `packaging/` directory. These changes are to avoid user frustration when attempting to use this as a guide for packaging their own app, not just following along with the example app.

**Edit:** I just saw that the other tutorials build on top of this one, so I'll need to update those as well to be a bit more modular like this one. I'll try and do that tonight if I have time.
