### PR TITLE
Fixed OpenSSL download URLs

### DIFF
--- a/linux/internal/setup-runtime-inside-mock
+++ b/linux/internal/setup-runtime-inside-mock
@@ -34,7 +34,7 @@ AUTOCONF_VERSION=2.69
 AUTOMAKE_VERSION=1.15
 LIBTOOL_VERSION=2.4.6
 CMAKE_VERSION=3.0.2
-OPENSSL_VERSION=1.0.2d
+OPENSSL_VERSION=1.0.2f
 FFI_VERSION=3.2.1
 SQLITE3_VERSION=3080702
 MYSQL_LIB_VERSION=6.1.5
@@ -140,7 +140,7 @@ echo
 header "Installing OpenSSL"
 if [[ ! -e /usr/local/override/bin/openssl ]]; then
 	download_and_extract openssl-$OPENSSL_VERSION.tar.gz \
-		http://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
+		https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
 	echo "Entering openssl-$OPENSSL_VERSION"
 	pushd openssl-$OPENSSL_VERSION >/dev/null
 

--- a/osx/setup-runtime
+++ b/osx/setup-runtime
@@ -223,7 +223,7 @@ PKG_CONFIG_VERSION=0.28
 AUTOCONF_VERSION=2.69
 AUTOMAKE_VERSION=1.15
 LIBTOOL_VERSION=2.4.6
-OPENSSL_VERSION=1.0.2d
+OPENSSL_VERSION=1.0.2f
 NCURSES_VERSION=5.9
 LIBEDIT_VERSION=20141030-3.1
 LIBEDIT_DIR_VERSION=20141029-3.1
@@ -385,7 +385,7 @@ if $SKIP_OPENSSL; then
 	echo "Skipped."
 elif [[ ! -e "$RUNTIME_DIR/lib/openssl-ok" ]] || $FORCE_OPENSSL; then
 	run rm -f openssl-$OPENSSL_VERSION.tar.gz
-	run curl --fail -L -O http://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
+	run curl --fail -L -O https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
 	run tar xzf openssl-$OPENSSL_VERSION.tar.gz
 	run rm openssl-$OPENSSL_VERSION.tar.gz
 	echo "Entering $RUNTIME_DIR/openssl-$OPENSSL_VERSION"


### PR DESCRIPTION
The other one was pointing to 

http://www.openssl.org/source/openssl-1.0.2d.tar.gz

this PR updates it to 

https://www.openssl.org/source/openssl-1.0.2f.tar.gz

which adds both `https` and switches to the `f` version