### PR TITLE
Added automatic installation of Xcode and 10.8 SDK

### DIFF
--- a/osx/README.md
+++ b/osx/README.md
@@ -13,17 +13,40 @@ You can view all tasks by running `rake -T`.
 
 You are required to use an older version of Xcode as you need to have the OS X 10.8 SDK installed locally. You can install Xcode 5.1.1 as follows.
 
-### 1. Download Xcode 5.1.1
+### The automated way
+
+Install [xcode-install](https://github.com/neonichu/xcode-install) using
+
+```
+[sudo] gem install xcode-install
+```
+
+```
+xcversion update
+xcversion install 5.1.1
+```
+
+This will install the old Xcode release in `/Applications/Xcode-5.1.1.app`.
+
+To copy over the SDK from the old Xcode to the new one, just run
+
+```
+rake install_sdk
+```
+
+### The manual way
+
+#### 1. Download Xcode 5.1.1
 
 Open the [Developer Portal download page](https://developer.apple.com/downloads/) and login with your Apple account. When you see the list of downloads, just open the [xcode_5.1.1.dmg link](http://adcdownload.apple.com/Developer_Tools/xcode_5.1.1/xcode_5.1.1.dmg) in your browser.
 
-### 2. Show Xcode package contents
+#### 2. Show Xcode package contents
 
 ![](https://raw.githubusercontent.com/phusion/traveling-ruby/master/doc/xcodepackage.jpg)
 
 Open the Xcode .dmg file. Right click on Xcode.app and choose "Show Package Contents".
 
-### 3. Locate OS X 10.8 SDK and copy it to the system
+#### 3. Locate OS X 10.8 SDK and copy it to the system
 
 ![](https://raw.githubusercontent.com/phusion/traveling-ruby/master/doc/sdk.jpg)
 

--- a/osx/Rakefile
+++ b/osx/Rakefile
@@ -31,6 +31,18 @@ task :clean do
   sh "rm -rf output"
 end
 
+desc "Installs the SDK"
+task :install_sdk do
+  from = "/Applications/Xcode-5.1.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk"
+  to = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs"
+
+  command = "sudo cp -R '#{from}' '#{to}'"
+  puts command
+  puts `#{command}`
+
+  puts "Successfully added the 10.8 SDK"
+end
+
 desc "Clean everything, including the runtime"
 task "clean-all" => :clean do
   sh "rm -rf runtime"


### PR DESCRIPTION
- Added instructions on how to use [xcode-install](https://github.com/neonichu/xcode-install) to install the old Xcode release
- Added new `install_sdk` rake task to automatically copy over the 10.8 SDK