### PR TITLE
Remove unnecessary backslashes in batch example

### DIFF
--- a/TUTORIAL-4.md
+++ b/TUTORIAL-4.md
@@ -16,11 +16,11 @@ Create `packaging/wrapper.bat`:
 @echo off
 
 :: Tell Bundler where the Gemfile and gems are.
-set "BUNDLE_GEMFILE=%~dp0\lib\vendor\Gemfile"
+set "BUNDLE_GEMFILE=%~dp0lib\vendor\Gemfile"
 set BUNDLE_IGNORE_CONFIG=
 
 :: Run the actual app using the bundled Ruby interpreter, with Bundler activated.
-@"%~dp0\lib\ruby\bin\ruby.bat" -rbundler/setup "%~dp0\lib\app\hello.rb"
+@"%~dp0lib\ruby\bin\ruby.bat" -rbundler/setup "%~dp0lib\app\hello.rb"
 ```
 
 ## Modifying the Rakefile


### PR DESCRIPTION
`%~dp0` will resolve to a value that has a trailing `\`. The \ included here is not needed as far as I can tell.
