### PR TITLE
Fix installing in path containing spaces

### DIFF
--- a/linux/internal/build-ruby-inside-mock
+++ b/linux/internal/build-ruby-inside-mock
@@ -55,13 +55,13 @@ echo ORIG_RUBYLIB=\"$RUBYLIB\"
 
 echo LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH:$ROOT/lib\"
 echo SSL_CERT_FILE=\"$ROOT/lib/ca-bundle.crt\"
-echo RUBYOPT=\"-r$ROOT/lib/restore_environment\"
+echo RUBYOPT=\"-rrestore_environment\"
 for DIR in "$ROOT"/lib/ruby/gems/*/deplibs/*/*; do
 	echo LD_LIBRARY_PATH=\"\$LD_LIBRARY_PATH:$DIR\"
 done
 EOF
-	echo "echo GEM_HOME=\"\$ROOT/lib/ruby/gems/$RUBY_COMPAT_VERSION\"" >> "$FILE"
-	echo "echo GEM_PATH=\"\$ROOT/lib/ruby/gems/$RUBY_COMPAT_VERSION\"" >> "$FILE"
+	echo "echo GEM_HOME=\\\"\$ROOT/lib/ruby/gems/$RUBY_COMPAT_VERSION\\\"" >> "$FILE"
+	echo "echo GEM_PATH=\\\"\$ROOT/lib/ruby/gems/$RUBY_COMPAT_VERSION\\\"" >> "$FILE"
 
 	cat >> "$FILE" <<EOF
 echo RUBYLIB=\"$LOAD_PATHS\"
@@ -183,7 +183,7 @@ run cp $LIBDIR/libtermcap.so.2 /tmp/ruby/lib/
 run cp $USRLIBDIR/libreadline.so.5 /tmp/ruby/lib/
 run cp $FFILIBDIR/libffi.so.6 /tmp/ruby/lib/
 run cp /system/ca-bundle.crt /tmp/ruby/lib/
-run cp /system/restore_environment.rb /tmp/ruby/lib/
+run cp /system/restore_environment.rb /tmp/ruby/lib/ruby/site_ruby/
 export SSL_CERT_FILE=/tmp/ruby/lib/ca-bundle.crt
 
 # Dump various information about the Ruby binaries.

--- a/osx/build-ruby
+++ b/osx/build-ruby
@@ -48,10 +48,10 @@ echo ORIG_RUBYLIB=\"$RUBYLIB\"
 
 echo TERMINFO=/usr/share/terminfo
 echo SSL_CERT_FILE=\"$ROOT/lib/ca-bundle.crt\"
-echo RUBYOPT=\"-r$ROOT/lib/restore_environment\"
+echo RUBYOPT=\"-rrestore_environment\"
 EOF
-	echo "echo GEM_HOME=\"\$ROOT/lib/ruby/gems/$RUBY_COMPAT_VERSION\"" >> "$FILE"
-	echo "echo GEM_PATH=\"\$ROOT/lib/ruby/gems/$RUBY_COMPAT_VERSION\"" >> "$FILE"
+	echo "echo GEM_HOME=\\\"\$ROOT/lib/ruby/gems/$RUBY_COMPAT_VERSION\\\"" >> "$FILE"
+	echo "echo GEM_PATH=\\\"\$ROOT/lib/ruby/gems/$RUBY_COMPAT_VERSION\\\"" >> "$FILE"
 
 	cat >> "$FILE" <<EOF
 echo RUBYLIB=\"$LOAD_PATHS\"
@@ -296,7 +296,7 @@ pushd "$TMPBUILDROOT" >/dev/null
 
 # Copy over various useful files.
 run cp -pR "$RUNTIME_DIR"/lib/*.dylib* lib/
-run cp "$SELFDIR/internal/restore_environment.rb" lib/
+run cp "$SELFDIR/internal/restore_environment.rb" lib/ruby/site_ruby/
 run cp "$SELFDIR/../shared/ca-bundle.crt" lib/
 export SSL_CERT_FILE="$TMPBUILDROOT/lib/ca-bundle.crt"
 


### PR DESCRIPTION
Installing to any directory with spaces in the path failed because of `GEM_HOME` and `GEM_PATH` having not enough quotes around them and ruby failing to parse the options from `RUBYOPT` when the `-r` option had spaces in it.

Fixed this by adding the necessary escapes to add doublequotes around the env variables and moved `restore_environment.rb` to the `lib/ruby/site_ruby/` folder, which is in the ruby load path, so the `-r` option doesn't need to reference the full absolute path.

Fixes #38.