### PR TITLE
Switch bash shebang from #!/bin/bash to #!/usr/bin/env bash

### DIFF
--- a/linux/build-ruby
+++ b/linux/build-ruby
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SELFDIR=`dirname "$0"`

--- a/linux/image/install.sh
+++ b/linux/image/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 # shellcheck source=linux/image/functions.sh
 source /tr_build/functions.sh

--- a/linux/internal/awsconfigure
+++ b/linux/internal/awsconfigure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 /hbb/bin/setuser app aws configure
 cp -dpR ~app/.aws /work/awscfg

--- a/linux/internal/awsinit
+++ b/linux/internal/awsinit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 cp -r /awscfg /root/.aws
 chown -R root: /root/.aws

--- a/linux/internal/build-ruby
+++ b/linux/internal/build-ruby
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # shellcheck source=shared/library.sh
@@ -16,7 +16,7 @@ function create_environment_file() {
 	LOAD_PATHS=`/tmp/ruby/bin.real/ruby /system_shared/dump-load-paths.rb`
 
 	cat > "$FILE" <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 ROOT=`dirname "$0"`
 ROOT=`cd "$ROOT/.." && pwd`
 
@@ -64,7 +64,7 @@ function create_wrapper()
 	local IS_RUBY_SCRIPT="$3"
 
 	cat > "$FILE" <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 ROOT=`dirname "$0"`
 ROOT=`cd "$ROOT/.." && pwd`

--- a/linux/internal/cpucount
+++ b/linux/internal/cpucount
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 grep "`echo -en 'processor\t'`" /proc/cpuinfo | wc -l

--- a/linux/package
+++ b/linux/package
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SELFDIR=`dirname "$0"`

--- a/linux/shell
+++ b/linux/shell
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SELFDIR=`dirname "$0"`

--- a/linux/test-gems
+++ b/linux/test-gems
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SELFDIR=`dirname "$0"`

--- a/linux/upload
+++ b/linux/upload
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SELFDIR=`dirname "$0"`


### PR DESCRIPTION
The bash installation path `/bin/bash` is not mandated by any standard, hence not all Linux distributions provide a binary at `/bin/bash`. As an example, I use NixOS as my daily driver, where `/bin/bash` is not a thing.

This change proposes to change the interpreter shebang to `/usr/bin/env bash` instead.
Using the `env` to lookup is considered the more portable solution, which goes in line with the project goals of providing a portable version of ruby.